### PR TITLE
Write big integers as strings on the tape instead of failing

### DIFF
--- a/include/simdjson/generic/numberparsing.h
+++ b/include/simdjson/generic/numberparsing.h
@@ -649,7 +649,7 @@ simdjson_warn_unused simdjson_inline error_code parse_number(const uint8_t *cons
     // - Therefore, if the number is positive and lower than that, it's overflow.
     // - The value we are looking at is less than or equal to INT64_MAX.
     //
-    }  else if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INVALID_NUMBER(src); }
+    }  else if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return BIGINT_NUMBER(src); }
   }
 
   // Write unsigned if it does not fit in a signed integer.

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -172,7 +172,23 @@ simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_string(
 
 simdjson_warn_unused simdjson_inline error_code tape_builder::visit_number(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("number");
-  return numberparsing::parse_number(value, tape);
+  error_code err = numberparsing::parse_number(value, tape);
+  if (err == BIGINT_ERROR) {
+    // Big integer does not fit in int64/uint64.
+    // Write it as a string on the tape so the consumer can parse it
+    // into a wider integer type (e.g. Int128, UInt256).
+    const uint8_t *p = value;
+    if (*p == '-') ++p;
+    while (*p >= '0' && *p <= '9') ++p;
+    size_t len = size_t(p - value);
+
+    uint8_t *dst = on_start_string(iter);
+    std::memcpy(dst, value, len);
+    dst += len;
+    on_end_string(dst);
+    return SUCCESS;
+  }
+  return err;
 }
 
 simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_number(json_iterator &iter, const uint8_t *value) noexcept {


### PR DESCRIPTION
## Summary

When `parse_number` encounters an integer that does not fit in `int64_t`/`uint64_t`, the DOM parser currently returns `BIGINT_ERROR`, causing the entire document parse to fail. This patch makes two changes:

1. **`numberparsing.h`** (line 652): A 20-digit positive integer that overflows `uint64_t` now correctly returns `BIGINT_ERROR` instead of `INVALID_NUMBER`. The number is valid JSON — it's just too large for 64 bits.

2. **`tape_builder.h`** (`visit_number`): Catches `BIGINT_ERROR` and writes the number's digit span (including an optional leading minus) as a `STRING` entry on the tape using the existing `on_start_string`/`on_end_string` infrastructure. This lets consumers (e.g. ClickHouse) read the raw digits and parse them into wider integer types such as `Int128` or `UInt256`.

### Why STRING?

- **No precision loss** — the exact digit string is preserved.
- **No new tape type** — avoids modifying `tape_type` enum, `element_type` enum, and all downstream consumers.
- **Tape/string buffer allocation is sufficient** — a STRING entry uses fewer tape slots (1) than a number entry (2), and the string buffer is already allocated to the full document length.

### Motivation

ClickHouse supports integer types wider than 64 bits (`UInt128`, `Int128`, `UInt256`, `Int256`). JSON documents containing large integers like `{"value": 123456789123456789123456789}` currently fail to parse entirely. With this patch, the big integer is stored as a string on the tape and ClickHouse's downstream code (which already handles string-to-wide-integer conversion) can process it correctly.