### PR TITLE
Validate terminator after big integer digit run

### DIFF
--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -180,6 +180,9 @@ simdjson_warn_unused simdjson_inline error_code tape_builder::visit_number(json_
     const uint8_t *p = value;
     if (*p == '-') ++p;
     while (*p >= '0' && *p <= '9') ++p;
+    // The character after the digit run must be structural or whitespace,
+    // otherwise the number token is malformed (e.g. "123456789123456789123x").
+    if (jsoncharutils::is_not_structural_or_whitespace(*p)) { return NUMBER_ERROR; }
     size_t len = size_t(p - value);
 
     uint8_t *dst = on_start_string(iter);


### PR DESCRIPTION
## Summary

The `BIGINT_ERROR` handler added in #4 copied the digit span to the string tape without checking the character that follows. This caused malformed tokens like `123456789123456789123x` to be silently accepted as valid JSON.

This adds the same `is_not_structural_or_whitespace` check that `parse_number` performs for normal integers (`numberparsing.h` line 670). Returns `NUMBER_ERROR` when the terminator is invalid.

**Before:** `parser.parse(R"({"a":123456789123456789123x})")` → `SUCCESS`
**After:** `parser.parse(R"({"a":123456789123456789123x})")` → `NUMBER_ERROR`